### PR TITLE
Python3 support

### DIFF
--- a/examples/ensemblesIntro.py
+++ b/examples/ensemblesIntro.py
@@ -24,7 +24,7 @@ for i in range(150):
     ecc = min(random.random()*0.75+0.5,0.8)
     # Create a Grain instance! elps_params = [major radius in cells, eccentricity]
     # default is 10 cells equivalent radius
-    grain = pss.Grain(shape='ellipse',rot=rot,elps_params=[10.,ecc])
+    grain = pss.Grain(shape='ellipse',rot=rot,eqr=10.,elps_eccen=ecc)
     # place the first 100 grains randomly into free spaces
     # for now we are just using one material.
     if i < 100: 

--- a/pySALESetup/__init__.py
+++ b/pySALESetup/__init__.py
@@ -11,7 +11,7 @@ import matplotlib.path   as mpath
 from collections import Counter, OrderedDict
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-from functions import *
+from pssfunctions import *
 from grainclasses import *
 from objectclasses import *
 from domainclasses import *

--- a/pySALESetup/__init__.py
+++ b/pySALESetup/__init__.py
@@ -1,9 +1,15 @@
+from __future__ import print_function
+from __future__ import absolute_import
+
 import random
 import warnings
 import numpy as np
 from PIL import Image
 from math import ceil
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except:
+    import pickle
 import scipy.special as scsp
 from scipy import stats as scst
 import matplotlib.pyplot as plt
@@ -11,16 +17,16 @@ import matplotlib.path   as mpath
 from collections import Counter, OrderedDict
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-from pssfunctions import *
-from grainclasses import *
-from objectclasses import *
-from domainclasses import *
+from .pssfunctions import *
+from .grainclasses import *
+from .objectclasses import *
+from .domainclasses import *
 
-print " ===================================================== "
-print "               _______   __   ________    __           "
-print "    ___  __ __/ __/ _ | / /  / __/ __/__ / /___ _____  "
-print "   / _ \/ // /\ \/ __ |/ /__/ _/_\ \/ -_) __/ // / _ \ "
-print "  / .__/\_, /___/_/ |_/____/___/___/\__/\__/\_,_/ .__/ "
-print " /_/   /___/                                   /_/     "
-print "                                      by J. G. Derrick "
-print " ===================================================== "
+print(" ===================================================== ")
+print("               _______   __   ________    __           ")
+print("    ___  __ __/ __/ _ | / /  / __/ __/__ / /___ _____  ")
+print("   / _ \/ // /\ \/ __ |/ /__/ _/_\ \/ -_) __/ // / _ \ ")
+print("  / .__/\_, /___/_/ |_/____/___/___/\__/\__/\_,_/ .__/ ")
+print(" /_/   /___/                                   /_/     ")
+print("                                      by J. G. Derrick ")
+print(" ===================================================== ")

--- a/pySALESetup/domainclasses.py
+++ b/pySALESetup/domainclasses.py
@@ -1,9 +1,15 @@
+from __future__ import print_function
+from __future__ import absolute_import
+
 import math
 import random
 import warnings
 import numpy as np
 from PIL import Image
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except:
+    import pickle
 from copy import deepcopy
 import scipy.special as scsp
 from scipy import stats as scst
@@ -12,9 +18,9 @@ import matplotlib.path   as mpath
 from collections import Counter, OrderedDict
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-import pssfunctions as psf
-import grainclasses as psg
-import objectclasses as pso
+#from . import grainclasses as psg
+#from . import objectclasses as pso
+#from . import pssfunctions as psf
 
 class Mesh:
     """
@@ -480,8 +486,8 @@ class Mesh:
         matrix_por = (matrix_vol - remain_vol)/float(matrix_vol)
         if Print:
             distension = 1./(1.-matrix_por)
-            print "bulk porosity = {:3.3f}%".format(bulk*100.)
-            print "Matrix: porosity = {:3.3f}% and distension = {:3.3f}".format(matrix_por*100.,distension)
+            print("bulk porosity = {:3.3f}%".format(bulk*100.))
+            print("Matrix: porosity = {:3.3f}% and distension = {:3.3f}".format(matrix_por*100.,distension))
         return matrix_por*100.
     
     def calcNoMats(self):
@@ -554,12 +560,12 @@ class Mesh:
             ALL  = np.column_stack((XI,YI,UX,UY,FRAC.transpose()))
         if compress: 
             fname += '.gz'
-            print "compressing..."
+            print("compressing...")
         else:
-            print "saving..."
+            print("saving...")
 
         np.savetxt(fname,ALL,header=HEAD,fmt='%5.3f',comments='')
-        print "saved"
+        print("saved")
     
     def save_oldver(self,fname='meso_m.iSALE'):
         """
@@ -597,7 +603,7 @@ class Mesh:
                 K += 1
         FRAC = self._checkFRACs(FRAC)
         HEAD = '{},{}'.format(K,NM)
-        print "Output mesh {} has shape {} x {}".format(fname,self.x,self.y)
+        print("Output mesh {} has shape {} x {}".format(fname,self.x,self.y))
         ALL  = np.column_stack((XI,YI,FRAC.transpose()))                                               
         np.savetxt(fname,ALL,header=HEAD,fmt='%5.3f',comments='')
     

--- a/pySALESetup/grainclasses.py
+++ b/pySALESetup/grainclasses.py
@@ -1,9 +1,15 @@
+from __future__ import print_function
+from __future__ import absolute_import
+
 import random
 import warnings
 import numpy as np
 from PIL import Image
 from math import ceil
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except:
+    import pickle
 import scipy.special as scsp
 from scipy import stats as scst
 import matplotlib.pyplot as plt
@@ -11,9 +17,9 @@ import matplotlib.path   as mpath
 from collections import Counter, OrderedDict
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-import domainclasses as psd
-import objectclasses as pso
-import pssfunctions as psf
+#from . import domainclasses as psd
+#from . import objectclasses as pso
+from . import pssfunctions as psf
 
 class Grain:
     """
@@ -26,7 +32,7 @@ class Grain:
     def __init__(self, eqr=10., rot=0., shape='circle', 
             File=None, elps_eccen=None, poly_params=None, mixed=False, name='grain1', Reload=False):
         """
-        When initialised the type of shape must be specified. Currently pySALESetup can handle N-sided polygons, 
+        When initialised the type of shape must be specified. Currently . can handle N-sided polygons, 
         circles and ellipses. Other shapes can be added if and when necessary (e.g. hybrids).
         Mixed cells mode has not been fully tested yet.   
 
@@ -44,7 +50,7 @@ class Grain:
         self.name = name
         if Reload:
             self.load()
-            print 'loaded {}'.format(self.name)
+            print('loaded {}'.format(self.name))
         else:
             self.equiv_rad = eqr
             self.angle = rot
@@ -73,7 +79,7 @@ class Grain:
             self.mesh = psf.grainfromVertices(R=poly_params,eqv_rad=self.equiv_rad,mixed=self.mixed,rot=rot)
             self.area = np.sum(self.mesh)
         else:
-            print "ERROR: unsupported string -- {} --  used for shape.".format(self.shape)
+            print("ERROR: unsupported string -- {} --  used for shape.".format(self.shape))
         # more to be added...
         self.Px,self.Py = np.shape(self.mesh)
     def details(self):
@@ -305,7 +311,7 @@ class Grain:
             if counter>10000:
                 nospace = True
                 passes= 1
-                print "No coords found after {} iterations; exiting".format(counter)
+                print("No coords found after {} iterations; exiting".format(counter))
                 break
         if nospace:
             pass
@@ -428,7 +434,7 @@ class Grain:
             nospace, overlap = self._checkCoords(x,y,target,overlap_max=cell_limit)
             counter += 1
             if counter>=10000:
-                print "No coords found after {} iterations; exiting".format(counter)
+                print("No coords found after {} iterations; exiting".format(counter))
                 break
         
             if nospace or (nospace == False  and overlap == 0):
@@ -490,7 +496,7 @@ class Ensemble:
         if Reload:
             self.load()
             self.hostmesh = hostmesh
-            print 'loaded {}'.format(self.name)
+            print('loaded {}'.format(self.name))
         else:
             self.hostmesh = hostmesh
             self.grains = []
@@ -675,7 +681,7 @@ class Ensemble:
         """
         Print out the area fraction; this is a user-accessible function
         """
-        print self._vfrac()
+        print(self._vfrac())
     
     def frequency(self):
         """

--- a/pySALESetup/objectclasses.py
+++ b/pySALESetup/objectclasses.py
@@ -1,9 +1,15 @@
+from __future__ import print_function
+from __future__ import absolute_import
+
 import random
 import warnings
 import numpy as np
 from PIL import Image
 from math import ceil
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except:
+    import pickle
 import scipy.special as scsp
 from scipy import stats as scst
 import matplotlib.pyplot as plt
@@ -11,9 +17,9 @@ import matplotlib.path   as mpath
 from collections import Counter, OrderedDict
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-import pssfunctions as psf
-import domainclasses as psd
-import grainclasses as psg
+#from . import pssfunctions as psf
+#from . import domainclasses as psd
+#from . import grainclasses as psg
 
 class Apparatus:
     """

--- a/pySALESetup/pssfunctions.py
+++ b/pySALESetup/pssfunctions.py
@@ -110,7 +110,7 @@ def combine_meshes(mesh2,mesh1,axis=1):
         Yw = mesh1.y + mesh2.y
         Xw = mesh1.x
     # cellsize and mixed not important here because all material already placed and output is independent of cellsize
-    New = Mesh(X=Xw,Y=Yw,cellsize=2.e-6,mixed=False,label=mesh2.name+mesh1.name)
+    New = psd.Mesh(X=Xw,Y=Yw,cellsize=2.e-6,mixed=False,label=mesh2.name+mesh1.name)
     New.materials = np.concatenate((mesh1.materials,mesh2.materials),axis=1+axis)
     New.mesh = np.concatenate((mesh1.mesh,mesh2.mesh),axis=axis)
     New.VX = np.concatenate((mesh1.VX,mesh2.VX),axis=axis)

--- a/pySALESetup/pssfunctions.py
+++ b/pySALESetup/pssfunctions.py
@@ -1,9 +1,15 @@
+from __future__ import print_function
+from __future__ import absolute_import
+
 import random
 import warnings
 import numpy as np
 from PIL import Image
 from math import ceil
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except:
+    import pickle
 import scipy.special as scsp
 from scipy import stats as scst
 import matplotlib.pyplot as plt
@@ -11,9 +17,9 @@ import matplotlib.path   as mpath
 from collections import Counter, OrderedDict
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-import domainclasses as psd
-import grainclasses as psg
-import objectclasses as pso
+from . import domainclasses as psd
+#from . import grainclasses as psg
+#from . import objectclasses as pso
 
 def quickFill(grain,target,volfrac,ensemble,
         material=1,method='insertion',xbnds=None,ybnds=None,nooverlap=False,mattargets=None):


### PR DESCRIPTION
Should now work with python 2 and 3. 

I commented out most of the imports of other pss modules at the top of the files, because they were causing circular imports (e.g. psd imported pso, which tried to import psd again, etc.). They don't actually get used at the moment, so I commented them out. 

If they are needed in future, it might be better to do, for example, this: `from .grainclasses import Grain` rather than `from . import grainclasses as psg`

Also note, cPickle doesn't exist in python 3. 

And you will need to install `pillow` instead of `PIL`, but it can still be imported as `PIL`