### PR TITLE
Ensemble method print_vfrac() printed None

### DIFF
--- a/pySALESetup/grainclasses.py
+++ b/pySALESetup/grainclasses.py
@@ -32,7 +32,7 @@ class Grain:
     def __init__(self, eqr=10., rot=0., shape='circle', 
             File=None, elps_eccen=None, poly_params=None, mixed=False, name='grain1', Reload=False):
         """
-        When initialised the type of shape must be specified. Currently . can handle N-sided polygons, 
+        When initialised the type of shape must be specified. Currently pySALESetup can handle N-sided polygons, 
         circles and ellipses. Other shapes can be added if and when necessary (e.g. hybrids).
         Mixed cells mode has not been fully tested yet.   
 

--- a/pySALESetup/grainclasses.py
+++ b/pySALESetup/grainclasses.py
@@ -676,6 +676,7 @@ class Ensemble:
         Calculate the area fraction the ensemble occupies in the domain
         """
         self.vfrac = np.sum(self.areas)/float(self.hostmesh.Ncells)
+        return self.vfrac
 
     def print_vfrac(self):
         """


### PR DESCRIPTION
This was because nothing was returned from the `_vfrac()` method. Fixed now so that method both stores `vfrac` in `self.vfrac`, and returns the value too